### PR TITLE
Minor fixes

### DIFF
--- a/demo-solutions.ipynb
+++ b/demo-solutions.ipynb
@@ -19,6 +19,7 @@
     "\n",
     "import jax\n",
     "import jax.numpy as jnp\n",
+    "import numpy as np\n",
     "import re\n",
     "from jaxtyping import Array, Float, Int\n",
     "import pytreeclass as pytc\n",
@@ -828,6 +829,7 @@
     }
    ],
    "source": [
+    "pars = params\n",
     "for i in range(num_iter):\n",
     "    sentences, sentence_labels = next(batch)\n",
     "    one_hot_sentences, one_hot_sentence_labels = batch_one_hot(\n",

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -762,6 +762,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "pars = params\n",
     "for i in range(num_iter):\n",
     "    sentences, sentence_labels = next(batch)\n",
     "    one_hot_sentences, one_hot_sentence_labels = batch_one_hot(\n",


### PR DESCRIPTION
Really small changes that seemed to be necessary to get things to run.

The `pars = params` change may not be correct, but hopefully it at least helps highlight the reason it wasn't working. The error output was:
```
NameError: name 'pars' is not defined
```